### PR TITLE
New option: JID from email address

### DIFF
--- a/ajax/getSettings.php
+++ b/ajax/getSettings.php
@@ -45,6 +45,18 @@ $data ['xmpp'] ['resource'] = $config->getAppValue('ojsxc', 'xmppResource');
 $data ['xmpp'] ['overwrite'] = validateBoolean($config->getAppValue('ojsxc', 'xmppOverwrite'));
 $data ['xmpp'] ['onlogin'] = true;
 
+if (validateBoolean($config->getAppValue('ojsxc', 'xmppPreferMail'))) {
+    $mail = $config->getUserValue($username,'settings','email');
+
+    if ($mail !== null) {
+	list($u, $d) = explode("@", $mail, 2);
+	if ($d !== null && $d !== "") {
+	    $data ['xmpp'] ['username'] = $u;
+	    $data ['xmpp'] ['domain'] = $d;
+	}
+    }
+}
+
 $options = $config->getUserValue($username, 'ojsxc', 'options');
 
 if ($options !== null) {

--- a/ajax/setAdminSettings.php
+++ b/ajax/setAdminSettings.php
@@ -8,6 +8,7 @@ $config = \OC::$server->getConfig();
 $config->setAppValue('ojsxc', 'serverType', $_POST ['serverType']);
 $config->setAppValue('ojsxc', 'boshUrl', $_POST ['boshUrl']);
 $config->setAppValue('ojsxc', 'xmppDomain', $_POST ['xmppDomain']);
+$config->setAppValue('ojsxc', 'xmppPreferMail', (isset($_POST ['xmppPreferMail'])) ? $_POST ['xmppPreferMail'] : 'false');
 $config->setAppValue('ojsxc', 'xmppResource', $_POST ['xmppResource']);
 $config->setAppValue('ojsxc', 'xmppOverwrite', (isset($_POST ['xmppOverwrite'])) ? $_POST ['xmppOverwrite'] : 'false');
 $config->setAppValue('ojsxc', 'xmppStartMinimized', (isset($_POST ['xmppStartMinimized'])) ? $_POST ['xmppStartMinimized'] : 'false');

--- a/settings.php
+++ b/settings.php
@@ -10,6 +10,7 @@ $tmpl = new OCP\Template('ojsxc', 'settings');
 $tmpl->assign('serverType', $config->getAppValue('ojsxc', 'serverType'));
 $tmpl->assign('boshUrl', $config->getAppValue('ojsxc', 'boshUrl'));
 $tmpl->assign('xmppDomain', $config->getAppValue('ojsxc', 'xmppDomain'));
+$tmpl->assign('xmppPreferMail', $config->getAppValue('ojsxc', 'xmppPreferMail'));
 $tmpl->assign('xmppResource', $config->getAppValue('ojsxc', 'xmppResource'));
 $tmpl->assign('xmppOverwrite', $config->getAppValue('ojsxc', 'xmppOverwrite'));
 $tmpl->assign('xmppStartMinimized', $config->getAppValue('ojsxc', 'xmppStartMinimized'));

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -22,6 +22,10 @@
 				<input type="text" name="xmppDomain" id="xmppDomain" class="required" required="required" value="<?php p($_['xmppDomain']); ?>" />
 			</div>
 			<div class="form-group">
+				<label for="xmppPreferMail">Prefer mail address to loginName@xmppDomain</label>
+				<input type="checkbox" name="xmppPreferMail" id="xmppPreferMail" value="true" <?php if($_['xmppPreferMail'] === 'true' || $_['xmppPreferMail'] === true) echo "checked"; ?> />
+			</div>
+			<div class="form-group">
 				<label for="boshUrl">* BOSH url</label>
 				<input type="text" name="boshUrl" id="boshUrl" class="required" required="required" value="<?php p($_['boshUrl']); ?>" />
 				<div class="boshUrl-msg"></div>

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -4,7 +4,7 @@
 		<div class="form-group">
 			<input type="radio" name="serverType" id="serverTypeInternal" required="required" value="internal" <?php if($_['serverType'] === 'internal')echo 'checked'; ?> />
 			<label for="serverTypeInternal">Internal (Experimental)</label>
-			<em>Internal server is not ready for production and contains not all features of an external server. To be precise only one-to-one messages are possible.</em>
+			<em>Limited functionality only: No clients besides JSXC in ownCloud, no multi-user chat, no server-to-server federations.</em>
 		</div>
 		<div class="form-group">
 			<input type="radio" name="serverType" id="serverTypeExternal" class="required" required="required" value="external" <?php if($_['serverType'] === 'external')echo 'checked'; ?> />


### PR DESCRIPTION
This adds an option, `xmppPreferMail` (default: false), to use the mail address, if any, as the default JID. 
As long as the option is unset or no mail address has been defined, the existing `loginName`@`xmppDomain` remains the default. Both can be overridden by the user when `xmppOverwrite` is set, as before.

In multi-domain environments, this extends the existing `xmppOverwrite` flexibility to providing useful defaults. In LDAP settings, the email address will often already be provided.

This solves in jsxc/jsxc#323. 

fix jsxc/jsxc#323
fix jsxc/jsxc#376

(The description of the internal server is also clarified in a separate commit)
