### PR TITLE
CSP: allow port number in BOSH URL

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -42,7 +42,7 @@ if(class_exists('\\OCP\\AppFramework\\Http\\EmptyContentSecurityPolicy')) {
 
 	$boshUrl = \OC::$server->getConfig()->getAppValue('ojsxc', 'boshUrl');
 
-	if(preg_match('#^(https?:)?//([a-z0-9][a-z0-9\-.]*[a-z0-9])/#i', $boshUrl, $matches)) {
+	if(preg_match('#^(https?:)?//([a-z0-9][a-z0-9\-.]*[a-z0-9](:[0-9]+)?)/#i', $boshUrl, $matches)) {
 		$boshDomain = $matches[2];
 
 		$policy->addAllowedConnectDomain($boshDomain);


### PR DESCRIPTION
Currently, if BOSH URL contains port number part (ex. :5280), it fails the regex and would not be added to CSP.
