### PR TITLE
Use regex to match full id instead of only letters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: php
 php:
-  - 5.4
-  - 5.5
   - 5.6
   - 7
 
@@ -17,12 +15,10 @@ env:
 
 matrix:
   include:
-    - php: 5.4
-      env: DB=sqlite
-    - php: 5.4
-      env: DB=pgsql
     - php: 5.6
-      env: DB=mysql
+      env: DB=sqlite
+    - php: 5.6
+      env: DB=pgsql
     - php: 5.6
       env: DB=mysql BRANCH=stable8
     - php: 5.6
@@ -32,6 +28,10 @@ matrix:
     - php: 5.6
       env: DB=mysql BRANCH=stable9
     - php: 5.6
+      env: DB=mysql BRANCH=stable9.1
+    - php: 5.4
+      env: DB=mysql BRANCH=stable9.1
+    - php: 5.5
       env: DB=mysql BRANCH=stable9.1
     - php: 5.6
       env: DB=mysql BRANCH=stable9 REPO=nc

--- a/lib/db/stanzamapper.php
+++ b/lib/db/stanzamapper.php
@@ -53,8 +53,8 @@ class StanzaMapper extends Mapper {
 		$stmt = $this->execute("SELECT stanza, id FROM *PREFIX*ojsxc_stanzas WHERE `to`=?", [$to]);
 		$results = [];
 		while($row = $stmt->fetch()){
-			$row['stanza'] = preg_replace('/to="([^"]*)"/', "to=\"$1@" .$this->host ."\"", $row['stanza']);
-			$row['stanza'] = preg_replace('/from="([^"]*)"/', "from=\"$1@" .$this->host ."\"", $row['stanza']);
+			$row['stanza'] = preg_replace('/to="([^"@]*)"/', "to=\"$1@" .$this->host ."\"", $row['stanza']);
+			$row['stanza'] = preg_replace('/from="([^"@]*)"/', "from=\"$1@" .$this->host ."\"", $row['stanza']);
 			$results[] = $this->mapRowToEntity($row);
 		}
 		$stmt->closeCursor();

--- a/lib/db/stanzamapper.php
+++ b/lib/db/stanzamapper.php
@@ -53,8 +53,8 @@ class StanzaMapper extends Mapper {
 		$stmt = $this->execute("SELECT stanza, id FROM *PREFIX*ojsxc_stanzas WHERE `to`=?", [$to]);
 		$results = [];
 		while($row = $stmt->fetch()){
-			$row['stanza'] = preg_replace('/to="([a-zA-z]*)"/', "to=\"$1@" .$this->host ."\"", $row['stanza']);
-			$row['stanza'] = preg_replace('/from="([a-zA-z]*)"/', "from=\"$1@" .$this->host ."\"", $row['stanza']);
+			$row['stanza'] = preg_replace('/to="([^"]*)"/', "to=\"$1@" .$this->host ."\"", $row['stanza']);
+			$row['stanza'] = preg_replace('/from="([^"]*)"/', "from=\"$1@" .$this->host ."\"", $row['stanza']);
 			$results[] = $this->mapRowToEntity($row);
 		}
 		$stmt->closeCursor();

--- a/tests/travis/install-oc-master.sh
+++ b/tests/travis/install-oc-master.sh
@@ -11,6 +11,7 @@ git clone https://github.com/owncloud/core.git --recursive --depth 1 -b $BRANCH 
 mv jsxc.chat owncloud/apps/ojsxc
 phpenv config-add owncloud/apps/ojsxc/tests/travis/php.ini
 cd owncloud
+make
 ./occ maintenance:install --database-name oc_autotest --database-user oc_autotest --database-pass --admin-user admin --admin-pass admin --database $DB
 ./occ app:enable ojsxc
 


### PR DESCRIPTION
Should fix https://github.com/jsxc/jsxc/issues/374

The problem was that a LDAP id contains not only letters but also other characters. (Weird that this bug didn't occurred earlier)