### PR TITLE
Make username case insentive when fetching settings Fixes jsxc/jsxc#382

### DIFF
--- a/ajax/getSettings.php
+++ b/ajax/getSettings.php
@@ -9,7 +9,7 @@ function validateBoolean($val)
 
 OCP\JSON::callCheck();
 
-$username = $_POST ['username'];
+$username = strtolower($_POST ['username']);
 $password = $_POST ['password'];
 
 $ocUser = new OCP\User();


### PR DESCRIPTION
The problem was in the way the getStetings.php try to authenticates the ownCloud/Nextcloud user.

@ungesundes-halbwissen can you try this patch? It should be enough to change the lay you can view in the diff view. Thanks!
